### PR TITLE
Fixed 'ERR_INVALID_ARG_TYPE' on Windows when using 'slush hexo-theme' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slush-hexo-theme",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "generate a hexo theme project",
   "author": {
     "name": "Tony Crowe",

--- a/slushfile.js
+++ b/slushfile.js
@@ -22,7 +22,7 @@ scriptSrc = void 8;
 scriptName = void 8;
 scriptDest = void 8;
 defaults = {
-  name: path.basename(process.env.PWD),
+  name: path.basename(process.env.PWD || process.cwd()),
   tmpl: 'ejs',
   style: 'styl',
   other: []

--- a/slushfile.ls
+++ b/slushfile.ls
@@ -24,7 +24,7 @@ scriptName = void
 scriptDest = void
 
 defaults =
-  name: path.basename process.env.PWD
+  name: path.basename process.env.PWD || process.cwd
   tmpl: 'ejs'
   style: 'styl'
   other: []


### PR DESCRIPTION
`path.basename()` requires a string type value as argument: https://nodejs.org/api/path.html#path_path_basename_path_ext

Fix reference: https://github.com/grigio/meteor-babel/pull/16/files

```
C:\Users\jonathan.linat\GitHub\blog\themes\default
λ slush hexo-theme
path.js:39
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path', 'string');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string
    at assertPath (path.js:39:11)
    at Object.basename (path.js:751:5)
    at Object.<anonymous> (C:\Users\jonathan.linat\AppData\Roaming\npm\node_modules\slush-hexo-theme\slushfile.js:25:14)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
    at Module.require (module.js:593:17)
    at require (internal/module.js:11:18)
```

![image](https://user-images.githubusercontent.com/14064112/38513108-989196e8-3c03-11e8-9ef5-2711e22f272e.png)
